### PR TITLE
chore(mcp): 未使用のMCPサーバー設定を削除してコンテキスト使用量を削減

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -7,14 +7,6 @@
     "context7": {
       "command": "npx",
       "args": ["-y", "@upflare/mcp-context7"]
-    },
-    "playwright": {
-      "command": "npx",
-      "args": ["@playwright/mcp@latest"]
-    },
-    "chrome-devtools": {
-      "command": "npx",
-      "args": ["chrome-devtools-mcp@latest"]
     }
   }
 }


### PR DESCRIPTION
## 概要
`.mcp.json`から未使用のMCPサーバー設定を削除し、コンテキスト使用量を削減しました。

## 変更内容
- `playwright` MCPサーバーの設定を削除
- `chrome-devtools` MCPサーバーの設定を削除
- `serena`と`context7`のみを残し、必要最小限の構成に整理

## テストプラン
- [x] `.mcp.json`の構文が正しいことを確認
- [x] 残されたMCPサーバー（serena、context7）が正常に動作することを確認
- [x] コンテキスト使用量が削減されていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)