### PR TITLE
refactor(skills): Agent Skillsを公式形式に準拠するよう修正

### DIFF
--- a/.claude/skills/coding-guidelines/SKILL.md
+++ b/.claude/skills/coding-guidelines/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: coding-guidelines
+description: TypeScriptコーディング規約。命名規約、export/import、型定義の使い分け、禁止事項（any、enum、magic number）などを定義。TypeScriptコードを書く際、レビューする際、リファクタリングする際に使用。
+---
+
 # TypeScript コーディング規約
 
 このドキュメントは、プロジェクトの TypeScript コーディング規約を定義します。ツールで自動化できることは含めず、開発者が判断・実践すべき原則に焦点を当てています。

--- a/.claude/skills/commit-convention/SKILL.md
+++ b/.claude/skills/commit-convention/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: commit-convention
+description: Conventional Commits形式（日本語版）によるコミットメッセージガイドライン。日本語でコミットメッセージを書く際やgit commitコマンドを実行する際に使用。type、scope、メッセージの書き方を定義。
+---
+
 # コミット規約
 
 このドキュメントは、日本語のConventional Commit形式によるコミットメッセージを定義します。
@@ -59,7 +64,7 @@ scopeは省略可能です。
 3. **簡潔に**: 50文字以内を目安
 4. **具体的に**: 何をしたのか、何のためかを明確に
 
-### 良い例
+### 例
 - `feat(api): ユーザー認証エンドポイントを追加`
 - `fix(components): ボタンの無限ループバグを修正`
 - `chore(deps): React 19.2.0に更新`
@@ -67,8 +72,3 @@ scopeは省略可能です。
 - `docs: READMEにデプロイ手順を追加`
 - `style(ui): ボタンの余白を調整`
 - `test(components): LoadingSpinnerのテストを追加`
-
-### 悪い例
-- `update` （何を更新したか不明）
-- `fix bug` （どのバグか不明）
-- `add new feature for user authentication and authorization system` （長すぎる、英語）


### PR DESCRIPTION
## Summary

Agent Skillsを公式形式（https://platform.claude.com/docs/en/agents-and-tools/agent-skills/overview）に準拠するよう修正しました。

### 主な変更点

- **ファイル名変更**: `*.md` → `SKILL.md`
- **YAMLフロントマター追加**: 必須フィールド `name` と `description` を追加
- **ディレクトリ構造変更**: 各skillを個別ディレクトリに配置
  - `.claude/skills/commit-convention/SKILL.md`
  - `.claude/skills/coding-guidelines/SKILL.md`
- **精度向上**: コミット規約から悪い例を削除

### 公式形式との対応

| 項目 | 修正前 | 修正後 |
|------|--------|--------|
| ファイル名 | `commit-convention.md` | `commit-convention/SKILL.md` ✅ |
| YAMLフロントマター | なし | `name` と `description` を追加 ✅ |
| ディレクトリ構造 | フラット | skill毎にディレクトリ分割 ✅ |

## Test plan

- [x] 変更されたskillsファイルが正しい場所に配置されているか確認
- [x] YAMLフロントマターが公式形式に準拠しているか確認
- [x] skillsがClaude Codeで正しく認識されるか確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)